### PR TITLE
feat: add bot greeting if convo history is empty

### DIFF
--- a/src/components/bot/ChatBox.jsx
+++ b/src/components/bot/ChatBox.jsx
@@ -217,6 +217,18 @@ const ChatBox = ({ className, closeUsing }) => {
     }
   };
 
+  const startGreetings = async () => {
+    const botResponse = "👋 Hello there! My name is Viviane, your friendly chatbot assistant. Welcome to our conversation! Whether you're here for assistance or information I'm here to help. Feel free to ask me anything or simply say hi."
+    await addDoc(messagesCollectionRef, {
+      intent: 'salutation.greetings',
+      message: botResponse,
+      role: "bot",
+      timeSent: Timestamp.now(),
+      uid: uid,
+    });
+    setBotMessage(botResponse);
+  }
+
   useEffect(() => {
     scrollInto(latestMessage);
   }, [messages, botIsTyping]);
@@ -236,6 +248,12 @@ const ChatBox = ({ className, closeUsing }) => {
       document.removeEventListener("keydown", handleSendMessageInEnter);
     };
   }, [userMessage]);
+
+  useEffect(() => {
+    if (!loading && messages.length === 0) {
+      startGreetings(); // initiate bot greetings
+    }
+  }, [loading]);
 
   return (
     <div


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Browser: Firefox
* Browser version:
* Text editor: VsCode

**Test Steps**:

1. Simulate an empty conversation:
   - Ensure that the `messages` state is empty.
   - Set `loading` to false.
   - Verify that the bot initiates greetings.
   
2. Simulate a conversation with messages:
   - Populate the `messages` state with some messages.
   - Set `loading` to false.
   - Verify that the bot does not initiate greetings.

**Expected Results**:
- When the conversation is empty (`messages.length === 0`), the bot should initiate greetings.
- When there are messages in the conversation (`messages.length > 0`), the bot should not initiate greetings.


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing functionality tests pass locally with my changes
